### PR TITLE
chore: fix ci + registry.conf old config

### DIFF
--- a/.github/workflows/tests-on-merge.yaml
+++ b/.github/workflows/tests-on-merge.yaml
@@ -17,6 +17,8 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install libbtrfs-dev libdevmapper-dev -y
+    - name: clear registry.conf
+      run: sudo mv /etc/containers/registries.conf /etc/containers/registries.conf-bkp
     - name: set up go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/tests-on-pr.yaml
+++ b/.github/workflows/tests-on-pr.yaml
@@ -17,13 +17,13 @@ jobs:
       run: |
         sudo apt-get update -y
         sudo apt-get install libbtrfs-dev libdevmapper-dev -y
+    - name: clear registry.conf
+      run: sudo mv /etc/containers/registries.conf /etc/containers/registries.conf-bkp
     - name: set up go
       uses: actions/setup-go@v5
       with:
         go-version: 1.23
     - name: check out code
       uses: actions/checkout@v4
-    - name: clear registry.conf
-      run: sudo mv /etc/containers/registries.conf /etc/containers/registries.conf-bkp
     - name: run tests
       run: go test -tags containers_image_openpgp -v ./...


### PR DESCRIPTION
github runner is using an old registry.conf and this commit changes the ci to ignore it.